### PR TITLE
Bug fix

### DIFF
--- a/gdecoder.cpp
+++ b/gdecoder.cpp
@@ -1241,7 +1241,7 @@ void GDecoder::knive(float knivedelay)
 	bool moveAbsolute=true;
   float units=1;
   float dir[2]={0,0};
-  int lastbreak,lastxmove=0,lastymove=0;
+  int lastbreak=0,lastxmove=0,lastymove=0;
   for(int i=0;i<wd.size();i++)
   {
 		struct Word &w=wd[i];


### PR DESCRIPTION
Use of uninitialised variable causes segfault in line 1255:
dir[0]=wd[i].curPos[0]-wd[lastbreak].curPos[0];
